### PR TITLE
Solution Helper still had references to old bucket name

### DIFF
--- a/deployment/build-s3-dist.sh
+++ b/deployment/build-s3-dist.sh
@@ -56,11 +56,6 @@ replace="s/%%VERSION%%/$2/g"
 echo "sed -i '' -e $replace $dist_dir/cost-optimization-monitor.template"
 sed -i '' -e "$replace" "$dist_dir"/cost-optimization-monitor.template
 
-echo "Updating dist bucket in template with $3"
-replace="s/%%DIST_BUCKET_NAME%%/$3/g"
-echo "sed -i '' -e $replace $dist_dir/cost-optimization-monitor.template"
-sed -i '' -e "$replace" "$dist_dir"/cost-optimization-monitor.template
-
 echo "------------------------------------------------------------------------------"
 echo "[Packing] ES Tools"
 echo "------------------------------------------------------------------------------"

--- a/deployment/cost-optimization-monitor.template
+++ b/deployment/cost-optimization-monitor.template
@@ -1778,7 +1778,7 @@
             "Fn::Join": [
               "",
               [
-                "%%DIST_BUCKET_NAME%%-",
+                "%%TEMPLATE_BUCKET_NAME%%-",
                 {
                   "Ref": "AWS::Region"
                 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
build-s3-dist.sh had an expectation of 3 parameters, of which only 2 were referenced in the README. The 3rd parameter appears to be an old variable as it is used by the SolutionHelper to load the helper.zip code which would refer to the TEMPLATE_BUCKET_NAME. 

Removed all references to DIST_BUCKET_NAME as it caused the cloudformation deploy to fail.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
